### PR TITLE
Fix null offset when child form is submitted without rows

### DIFF
--- a/src/controllers/CBController.php
+++ b/src/controllers/CBController.php
@@ -1258,7 +1258,7 @@ class CBController extends Controller
                 $name = str_slug($ro['label'], '');
                 $columns = $ro['columns'];
                 $getColName = request($name.'-'.$columns[0]['name']);
-                $count_input_data = ($getColName)?(count($getColName) - 1):0;
+                $count_input_data = is_array($getColName) ? (count($getColName) - 1) : -1;
                 $child_array = [];
                 $fk = $ro['foreign_key'];
 
@@ -1266,7 +1266,8 @@ class CBController extends Controller
                     $column_data = [];
                     foreach ($columns as $col) {
                         $colname = $col['name'];
-                        $colvalue = request($name.'-'.$colname)[$i];
+                        $requestData = request($name.'-'.$colname);
+                        $colvalue = is_array($requestData) ? ($requestData[$i] ?? null) : null;
                         if(isset($colvalue) === TRUE) {
                             $column_data[$colname] = $colvalue;
                         }
@@ -1278,7 +1279,9 @@ class CBController extends Controller
                 }
 
                 $childtable = CRUDBooster::parseSqlTable($ro['table'])['table'];
-                DB::table($childtable)->insert($child_array);
+                if (!empty($child_array)) {
+                    DB::table($childtable)->insert($child_array);
+                }
             }
         }
 
@@ -1406,7 +1409,7 @@ class CBController extends Controller
                 $name = str_slug($ro['label'], '');
                 $columns = $ro['columns'];
                 $getColName = request($name.'-'.$columns[0]['name']);
-                $count_input_data = ($getColName)?(count($getColName) - 1):0;
+                $count_input_data = is_array($getColName) ? (count($getColName) - 1) : -1;
                 $child_array = [];
                 $childtable = CRUDBooster::parseSqlTable($ro['table'])['table'];
                 $fk = $ro['foreign_key'];
@@ -1419,7 +1422,8 @@ class CBController extends Controller
                     $column_data = [];
                     foreach ($columns as $col) {
                         $colname = $col['name'];
-                        $colvalue = request($name.'-'.$colname)[$i];
+                        $requestData = request($name.'-'.$colname);
+                        $colvalue = is_array($requestData) ? ($requestData[$i] ?? null) : null;
                         if(isset($colvalue) === TRUE) {
                             $column_data[$colname] = $colvalue;
                         }
@@ -1432,7 +1436,9 @@ class CBController extends Controller
                     }
                 }
                 $child_array = array_reverse($child_array);
-                DB::table($childtable)->insert($child_array);
+                if (!empty($child_array)) {
+                    DB::table($childtable)->insert($child_array);
+                }
             }
         }
 


### PR DESCRIPTION
https://quaira.atlassian.net/browse/YSW-1412

## Summary
Fixes `ErrorException: Trying to access array offset on value of type null` at `src/controllers/CBController.php:1422` (and the equivalent line in `postAddSave`). This is YAKU-3K / [YSW-1412](https://quaira.atlassian.net/browse/YSW-1412) on the Yaku side.

## Root cause
In `postAddSave` and `postEditSave`, the `type == 'child'` block did:

```php
$getColName = request($name.'-'.$columns[0]['name']);
$count_input_data = ($getColName) ? (count($getColName) - 1) : 0;
...
for ($i = 0; $i <= $count_input_data; $i++) {
    foreach ($columns as $col) {
        $colvalue = request($name.'-'.$colname)[$i]; // null[$i] when nothing submitted
    }
}
```

When the child form is submitted with no rows, `$getColName` is `null`, `$count_input_data` becomes `0`, and the loop still executes once. The inner `request(...)[$i]` then dereferences `null`, throwing the exception.

## Changes
- `$count_input_data = is_array($getColName) ? (count($getColName) - 1) : -1;` — skip the loop entirely when the first column isn't an array.
- Guard the per-column lookup: `is_array($requestData) ? ($requestData[$i] ?? null) : null` — defensive against any individual column missing while others are present.
- Skip the final `DB::table($childtable)->insert($child_array)` when `$child_array` is empty (avoids a no-op/error insert).

Applied symmetrically to both `postAddSave` and `postEditSave`.

## Test plan
- [ ] Submit an edit form with a `type=child` subform and **no rows** → should save without ErrorException.
- [ ] Submit with rows → existing behavior preserved (insert works).
- [ ] On create, submit with no child rows → parent record created, no child insert attempted.
- [ ] On edit, delete all existing child rows and save → existing children removed, no re-insert, no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)